### PR TITLE
Improve rich text editor toolbar styling

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7,6 +7,7 @@
             "dependencies": {
                 "prosemirror-commands": "^1.7.1",
                 "prosemirror-history": "^1.4.1",
+                "prosemirror-inputrules": "^1.5.0",
                 "prosemirror-keymap": "^1.2.3",
                 "prosemirror-model": "^1.25.2",
                 "prosemirror-schema-basic": "^1.2.4",
@@ -1809,6 +1810,16 @@
                 "prosemirror-transform": "^1.0.0",
                 "prosemirror-view": "^1.31.0",
                 "rope-sequence": "^1.3.0"
+            }
+        },
+        "node_modules/prosemirror-inputrules": {
+            "version": "1.5.0",
+            "resolved": "https://registry.npmjs.org/prosemirror-inputrules/-/prosemirror-inputrules-1.5.0.tgz",
+            "integrity": "sha512-K0xJRCmt+uSw7xesnHmcn72yBGTbY45vm8gXI4LZXbx2Z0jwh5aF9xrGQgrVPu0WbyFVFF3E/o9VhJYz6SQWnA==",
+            "license": "MIT",
+            "dependencies": {
+                "prosemirror-state": "^1.0.0",
+                "prosemirror-transform": "^1.0.0"
             }
         },
         "node_modules/prosemirror-keymap": {

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
         "prosemirror-schema-basic": "^1.2.4",
         "prosemirror-schema-list": "^1.5.1",
         "prosemirror-state": "^1.4.3",
-        "prosemirror-view": "^1.40.1"
+        "prosemirror-view": "^1.40.1",
+        "prosemirror-inputrules": "^1.5.0"
     }
 }

--- a/resources/css/app.css
+++ b/resources/css/app.css
@@ -199,3 +199,14 @@ dialog::backdrop {
 [data-tooltip]:hover::after{
     --scale: 1;
 }
+
+/* Style for rich text editor toolbar */
+[data-rich-text-editor] .toolbar .toolbar-item {
+    @apply rounded-md border border-gray-300 bg-gray-50 px-2 py-1 text-sm text-gray-600 hover:bg-gray-100 active:bg-gray-200 focus:outline-none;
+}
+
+/* Remove focus outline from editor */
+[data-rich-text-editor] .editor .ProseMirror:focus,
+[data-rich-text-editor] .editor .ProseMirror-focused {
+    @apply outline-none;
+}

--- a/resources/js/modules/rich-text-editor.js
+++ b/resources/js/modules/rich-text-editor.js
@@ -6,6 +6,7 @@ import {addListNodes, wrapInList} from 'prosemirror-schema-list'
 import {history, undo, redo} from 'prosemirror-history'
 import {keymap} from 'prosemirror-keymap'
 import {baseKeymap, toggleMark, setBlockType, wrapIn} from 'prosemirror-commands'
+import {inputRules, textblockTypeInputRule} from 'prosemirror-inputrules'
 
 const underline = {
     parseDOM: [{tag: 'u'}, {style: 'text-decoration=underline'}],
@@ -60,6 +61,7 @@ export function init() {
             doc: ProseParser.fromSchema(schema).parse(content.body),
             plugins: [
                 history(),
+                inputRules({rules: buildInputRules(schema)}),
                 keymap(baseKeymap)
             ]
         })
@@ -167,4 +169,12 @@ function getHTML(doc, schema){
     const div = document.createElement('div')
     div.appendChild(DOMSerializer.fromSchema(schema).serializeFragment(doc.content))
     return div.innerHTML
+}
+
+function buildInputRules(schema){
+    const rules = []
+    if(schema.nodes.heading){
+        rules.push(textblockTypeInputRule(/^(#{1,6})\s$/, schema.nodes.heading, match => ({level: match[1].length})) )
+    }
+    return rules
 }

--- a/resources/views/components/forms/rich-text-editor.blade.php
+++ b/resources/views/components/forms/rich-text-editor.blade.php
@@ -4,27 +4,27 @@
     $id = $id ?? Str::uuid()->toString();
 @endphp
 <div id="{{ $id }}" data-rich-text-editor class="bg-white p-2 border border-gray-300 rounded-md">
-    <div class="toolbar flex flex-wrap gap-1 mb-2">
-        <select data-command="heading" class="border rounded p-1 text-sm">
+    <div class="toolbar flex flex-wrap gap-1 mb-2 text-gray-600">
+        <select data-command="heading" class="toolbar-item text-sm">
             <option value="0">Parágrafo</option>
             <option value="1">H1</option>
             <option value="2">H2</option>
             <option value="3">H3</option>
         </select>
-        <button type="button" data-command="bold" class="px-1 font-bold">B</button>
-        <button type="button" data-command="italic" class="px-1 italic">I</button>
-        <button type="button" data-command="strike" class="px-1 line-through">S</button>
-        <button type="button" data-command="underline" class="px-1 underline">U</button>
-        <button type="button" data-command="bullet" class="px-1">•</button>
-        <button type="button" data-command="ordered" class="px-1">1.</button>
-        <button type="button" data-command="blockquote" class="px-1">"</button>
-        <button type="button" data-command="code" class="px-1">{ }</button>
-        <button type="button" data-command="link" class="px-1">🔗</button>
-        <button type="button" data-command="align-left" class="px-1">⬅</button>
-        <button type="button" data-command="align-center" class="px-1">↔</button>
-        <button type="button" data-command="align-right" class="px-1">➡</button>
-        <button type="button" data-command="undo" class="px-1">↶</button>
-        <button type="button" data-command="redo" class="px-1">↷</button>
+        <button type="button" data-command="bold" class="toolbar-item font-bold">B</button>
+        <button type="button" data-command="italic" class="toolbar-item italic">I</button>
+        <button type="button" data-command="strike" class="toolbar-item line-through">S</button>
+        <button type="button" data-command="underline" class="toolbar-item underline">U</button>
+        <button type="button" data-command="bullet" class="toolbar-item">•</button>
+        <button type="button" data-command="ordered" class="toolbar-item">1.</button>
+        <button type="button" data-command="blockquote" class="toolbar-item">"</button>
+        <button type="button" data-command="code" class="toolbar-item">{ }</button>
+        <button type="button" data-command="link" class="toolbar-item">🔗</button>
+        <button type="button" data-command="align-left" class="toolbar-item">⬅</button>
+        <button type="button" data-command="align-center" class="toolbar-item">↔</button>
+        <button type="button" data-command="align-right" class="toolbar-item">➡</button>
+        <button type="button" data-command="undo" class="toolbar-item">↶</button>
+        <button type="button" data-command="redo" class="toolbar-item">↷</button>
     </div>
     <div class="editor min-h-[100px] outline-none"></div>
 </div>


### PR DESCRIPTION
## Summary
- refine toolbar item classes on rich text editor component
- introduce Tailwind styles for new `toolbar-item` class
- remove focus outline from editor
- add ProseMirror input rule for markdown-style heading shortcuts

## Testing
- `./vendor/bin/phpunit --stop-on-failure`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6884dbf0cc5083269ca290250f5a8a5d