### PR TITLE
Enhance markdown editing features

### DIFF
--- a/resources/css/app.css
+++ b/resources/css/app.css
@@ -205,6 +205,9 @@ dialog::backdrop {
 [data-rich-text-editor] .toolbar .toolbar-item {
     @apply p-1.5 text-base text-gray-600 border-1 border-transparent hover:border-gray-200 hover:border-1 hover:bg-gray-100 active:bg-gray-200 focus:outline-none;
 }
+[data-rich-text-editor] .toolbar .toolbar-item.active {
+    @apply bg-gray-200 border-gray-200;
+}
 
 /* Remove focus outline from editor */
 [data-rich-text-editor] .editor .ProseMirror:focus,


### PR DESCRIPTION
## Summary
- highlight active toolbar items and show current heading level
- add trailing paragraph plugin to allow new blocks below pasted code
- enable undo/redo shortcuts
- keep toolbar status in sync when selection changes

## Testing
- `npm run build`
- `php artisan test --stop-on-failure`


------
https://chatgpt.com/codex/tasks/task_e_6884e814ac388326a8061f9ae647933a